### PR TITLE
ESRCH graceful error handling when log process is already dead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,12 +74,14 @@ const cmd = streamCommand(
   INPUTS.path,
 );
 main()
-  .then(() => {
-    // need to make sure all spawned processes are killed
-    process.kill(-cmd.pid);
-  })
   .catch((err) => {
     error(err);
+    // make an attempt to kill the process
+    process.kill(-cmd.pid);
+    process.exit(1);
+  })
+  .then(() => {
+    // attempt to kill the process then kill the process
     process.kill(-cmd.pid);
     process.exit(0);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,5 +81,5 @@ main()
   .catch((err) => {
     error(err);
     process.kill(-cmd.pid);
-    process.exit(1);
+    process.exit(0);
   });


### PR DESCRIPTION
# What changed

This ensures that the process exits with the correct exit code. There may be a case where the services are marked as healthy but the logging process id does not exist. In this case we can consider this successful even though we encountered an `ESRCH` error.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - ESRCH graceful error handling when log process is already dead [#35](https://github.com/ejhayes/docker-compose-wait-for-healthy/pull/35) ([@ejhayes](https://github.com/ejhayes))
  
  #### Authors: 1
  
  - Eric Hayes ([@ejhayes](https://github.com/ejhayes))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
